### PR TITLE
On GHA check only with ubuntu-release

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, master]
 
-name: R-CMD-check
+name: R-CMD-check.yaml
 
 permissions: read-all
 
@@ -20,11 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This repo is using most of our quota for GitHub Actions. One easy
way to use fewer resources is to run the R CMD check workflow on
just Ubuntu release.

This code isn't user-facing. It  needs to run just on our laptops. 
And the maintainer Kalash uses a system different than Ubuntu (I
believe) meaning that the code is checked on two platforms: Ubuntu
on GHA and one other platform on Kalash's laptop.

Usage report: https://gist.github.com/maurolepore/4f42c89fa29e4280a0b8f16b3b1d459a
